### PR TITLE
Fix/stale responses

### DIFF
--- a/api/controllers/ABModelController.js
+++ b/api/controllers/ABModelController.js
@@ -18,6 +18,32 @@ const { ref, raw } = require('objection');
 
 var reloading = null;
 
+var countPendingTransactions = 0;
+var countResolvedTransactions = 0;
+
+
+setInterval(()=>{
+
+    if (countResolvedTransactions > 0) {
+        var countRemaining = countPendingTransactions - countResolvedTransactions;
+        sails.log(`::: ${countResolvedTransactions} processed in last second. ${countRemaining} Transactions still in Process. `);
+    }
+    countPendingTransactions = countPendingTransactions - countResolvedTransactions;
+    if (countPendingTransactions < 0) countPendingTransactions = 0;
+    countResolvedTransactions = 0;
+
+}, 1000);
+
+function newPendingTransaction() {
+    countPendingTransactions += 1;
+}
+
+function resolvePendingTransaction() {
+    countResolvedTransactions += 1;
+    if (countResolvedTransactions > countPendingTransactions) {
+        countPendingTransactions = countPendingTransactions;
+    }
+}
 
 /** 
  * @function updateRelationValues
@@ -307,7 +333,7 @@ module.exports = {
 
     create: function (req, res) {
 
-
+        newPendingTransaction();
         AppBuilder.routes.verifyAndReturnObject(req, res)
             .then(function (object) {
 
@@ -380,6 +406,7 @@ module.exports = {
                                         req.user.data)
                                         .then((newItem) => {
 
+                                            resolvePendingTransaction();
                                             res.AD.success(newItem[0]);
 
                                             // We want to broadcast the change from the server to the client so all datacollections can properly update
@@ -428,6 +455,7 @@ module.exports = {
                                     })
                                 }
 
+                                resolvePendingTransaction();
                                 res.AD.error(errorResponse);
                             }
                             else {
@@ -449,6 +477,7 @@ module.exports = {
 
                                 });
 
+                                resolvePendingTransaction();
                                 res.AD.error(errorResponse);
                             }
 
@@ -458,6 +487,7 @@ module.exports = {
 
                             if (!(err instanceof ValidationError)) {
                                 ADCore.error.log('Error performing update!', { error: err })
+                                resolvePendingTransaction();
                                 res.AD.error(err);
                                 sails.log.error('!!!! error:', err);
                             }
@@ -482,6 +512,7 @@ module.exports = {
                         attr[e.name].push(e);
                     })
 
+                    resolvePendingTransaction();
                     res.AD.error(errorResponse);
                 }
 
@@ -498,7 +529,7 @@ module.exports = {
      */
     find: function (req, res) {
 
-
+        newPendingTransaction();
         AppBuilder.routes.verifyAndReturnObject(req, res)
             .then(function (object) {
 
@@ -566,7 +597,7 @@ module.exports = {
                                 // object.postGet(result.data)
                                 // .then(()=>{
 
-
+                                resolvePendingTransaction();
                                 if (res.header) res.header('Content-type', 'application/json');
 
                                 res.send(result, 200);
@@ -577,7 +608,7 @@ module.exports = {
 
                         })
                         .catch((err) => {
-
+                            resolvePendingTransaction();
                             res.AD.error(err);
 
                         });
@@ -585,6 +616,7 @@ module.exports = {
                     })
                     .catch((err) => {
 
+                        resolvePendingTransaction();
                         res.AD.error(err);
 
                     });
@@ -594,6 +626,7 @@ module.exports = {
 
             })
             .catch((err) => {
+                resolvePendingTransaction();
                 ADCore.error.log("AppBuilder:ABModelController:find(): find() did not complete", { error: err });
                 res.AD.error(err, err.HTTPCode || 400);
             });
@@ -617,6 +650,7 @@ module.exports = {
             return;
         }
 
+        newPendingTransaction();
         async.series([
             // step #1
             function (next) {
@@ -741,6 +775,7 @@ module.exports = {
                     .deleteById(id)
                     .then((numRows) => {
 
+                        resolvePendingTransaction();
                         res.AD.success({ numRows: numRows });
 
                         // We want to broadcast the change from the server to the client so all datacollections can properly update
@@ -770,6 +805,7 @@ module.exports = {
         ], function (err) {
             if (err) {
                 if (!(err instanceof ValidationError)) {
+                    resolvePendingTransaction();
                     ADCore.error.log('Error performing delete!', { error: err })
                     res.AD.error(err);
                     sails.log.error('!!!! error:', err);
@@ -938,6 +974,7 @@ module.exports = {
             return;
         }
 
+        newPendingTransaction();
         AppBuilder.routes.verifyAndReturnObject(req, res)
             .then(function (object) {
 
@@ -1056,6 +1093,7 @@ module.exports = {
                                             return query3
                                                 .catch((err) => { return Promise.reject(err); })
                                                 .then((newItem) => {
+                                                    resolvePendingTransaction();
                                                     res.AD.success(newItem[0]);
 
                                                     // We want to broadcast the change from the server to the client so all datacollections can properly update
@@ -1078,6 +1116,8 @@ module.exports = {
                                 }, (err) => {
 
                                     console.log('...  (err) handler!', err);
+
+                                    resolvePendingTransaction();
 
                                     // handle invalid values here:
                                     if (err instanceof ValidationError) {
@@ -1133,7 +1173,8 @@ module.exports = {
                                     console.log('... catch(err) !');
 
                                     if (!(err instanceof ValidationError)) {
-                                        ADCore.error.log('Error performing update!', { error: err })
+                                        ADCore.error.log('Error performing update!', { error: err });
+                                        resolvePendingTransaction();
                                         res.AD.error(err);
                                         sails.log.error('!!!! error:', err);
                                     }
@@ -1158,6 +1199,7 @@ module.exports = {
                                 attr[e.name].push(e);
                             })
 
+                            resolvePendingTransaction();
                             res.AD.error(errorResponse);
                         }
 
@@ -1172,6 +1214,8 @@ module.exports = {
     upsert: function (req, res) {
 
         var object;
+
+        newPendingTransaction();
 
         Promise.resolve()
             .then(() => {
@@ -1271,6 +1315,7 @@ module.exports = {
                             attr[e.name].push(e);
                         });
 
+                        resolvePendingTransaction();
                         res.AD.error(errorResponse);
 
                         return;
@@ -1343,6 +1388,7 @@ module.exports = {
                         req.user.data)
                         .then((updateItem) => {
 
+                            resolvePendingTransaction();
                             res.AD.success(updateItem);
 
                             // We want to broadcast the change from the server to the client so all datacollections can properly update
@@ -1366,6 +1412,8 @@ module.exports = {
             .catch((err) => {
 
                 console.log('...  (err) handler!', err);
+
+                resolvePendingTransaction();
 
                 // handle invalid values here:
                 if (err instanceof ValidationError) {
@@ -1400,11 +1448,13 @@ module.exports = {
 
     refresh: function (req, res) {
 
+        newPendingTransaction();
         AppBuilder.routes.verifyAndReturnObject(req, res)
             .then(function (object) {
 
                 object.modelRefresh();
 
+                resolvePendingTransaction();
                 res.AD.success({});
 
             });
@@ -1414,6 +1464,7 @@ module.exports = {
 
     count: function (req, res) {
 
+        newPendingTransaction();
         AppBuilder.routes.verifyAndReturnObject(req, res)
             .then(function (object) {
 
@@ -1426,6 +1477,7 @@ module.exports = {
                     .catch(res.AD.error)
                     .then(result => {
 
+                        resolvePendingTransaction();
                         res.AD.success(result);
 
                     });

--- a/assets/opstools/AppBuilder/classes/ABModel.js
+++ b/assets/opstools/AppBuilder/classes/ABModel.js
@@ -67,6 +67,12 @@ export default class ABModel {
 		this._sort = null;
 		this._skip = null;
 		this._limit = null;
+
+		this.staleRefreshInProcess = false;
+		this.staleRefreshMap = { /* id : Promise */ };
+		this.staleRefreshPending = [];
+		this.staleRefreshTimerID = null;
+
 	}
 
 
@@ -170,6 +176,136 @@ export default class ABModel {
 
 			}
 		)
+
+	}
+
+
+
+	/**
+	 * @method staleRefresh
+	 * Process a request to refresh the data for a given entry.
+	 * This method is called from a ABViewDataCollection when it receives 
+	 * a 'ab.datacollection.stale' message.
+	 * This method will try to queue similar reqeusts and then issue 1 large
+	 * request, rather than numerous individual ones.
+	 * @param {obj} cond  the condition of the entry we are requesting.
+	 * @return {Promise}
+	 */
+	staleRefresh(cond) {
+
+		// cond should be { where:{ id: X } } format.
+		var currID = cond.id;  // but just in case we get a { id: X }
+		if (cond.where) {
+			currID = cond.where.id;
+		}
+
+		return new Promise((resolve, reject)=>{
+
+			if (!currID) {
+				var Err = new Error('Model.staleRefresh(): could not resolve .id ');
+				Err.cond = cond;
+				reject(Err);
+				return;
+			}
+
+
+			// convert to ID : Promise object:
+			var entry = {
+				id: currID,
+				resolve: resolve,
+				reject: reject
+			}
+
+			// queue up refresh condition
+			this.staleRefreshPending.push(entry);
+
+			// if ! staleRefreshInProcess
+			if (!this.staleRefreshInProcess) {
+				
+				// set timeout to another 200ms wait after LAST staleRefresh()
+				if (this.staleRefreshTimerID) {
+					clearTimeout(this.staleRefreshTimerID);
+				}
+				this.staleRefreshTimerID = setTimeout(()=>{
+					this.staleRefreshProcess();
+				}, 200);
+			}
+		})
+
+	}
+
+
+
+	/**
+	 * @method staleRefreshProcess
+	 * Actually process the current pending requests.
+	 */
+	staleRefreshProcess() {
+
+		this.staleRefreshInProcess = true;
+		var currentEntries = this.staleRefreshPending;
+		this.staleRefreshPending = [];
+
+		var responseHash = { /* id : {entry} */ };
+		var cond = { where:{ id:[] } };
+
+		console.log('Model.staleRefreshProcess(): buffered '+currentEntries.length+' requests');
+		currentEntries.forEach((e)=>{
+			responseHash[e.id] = responseHash[e.id] || [];
+			responseHash[e.id].push(e);
+		})
+
+		cond.where.id = Object.keys(responseHash);
+
+		this.findAll(cond)
+		.then((res)=>{
+
+			// for each entry we got back
+			if (Array.isArray(res.data) && res.data.length) {
+				res.data.forEach((data)=>{
+
+					// find it's matching request:
+					if (responseHash[data.id]) {
+
+						// respond to the pending promise
+						// and remove these entries from responseHash
+						var entries = responseHash[data.id];
+						entries.forEach((entry)=>{
+							var resolve = entry.resolve;
+							resolve({ data:[data]});
+						})
+						
+						delete responseHash[data.id];
+
+					} else {
+						console.error('Model.staleRefreshProcess(): returned entry was not in our responseHash:', data, responseHash);
+					}
+				})
+			}
+
+			// now if there are any entries left in responseHash,
+			// respond with an empty entry:
+			var allKeys = Object.keys(responseHash);
+			if (allKeys.length > 0) {
+				console.warn('Model.staleRefreshProcess(): '+allKeys.length+' entries with no responses. ');
+			}
+			allKeys.forEach((key)=>{
+				var resolve = responseHash[key].resolve;
+				resolve({ data:[]});
+				delete responseHash[data.id];
+			})
+
+
+			// now check to see if there are any more pending requests:
+			if (this.staleRefreshPending.length > 0) {
+				// process them:
+				this.staleRefreshProcess();
+			} else {
+				// mark we are no longer processing stale requests.
+				this.staleRefreshInProcess = false;
+			}
+
+		})
 
 	}
 

--- a/assets/opstools/AppBuilder/classes/views/ABViewDataCollection.js
+++ b/assets/opstools/AppBuilder/classes/views/ABViewDataCollection.js
@@ -1123,7 +1123,7 @@ export default class ABViewDataCollection extends ABView {
 
 				if (this.__dataCollection.exists(values.id)) {
 					// this data collection has the record so we need to query the server to find out what it's latest data is so we can update all instances
-					this.model.findAll({ where: { id: values.id } }).then((res) => {
+					this.model.staleRefresh({ where: { id: values.id } }).then((res) => {
 
 						// check to make sure there is data to work with
 						if (Array.isArray(res.data) && res.data.length) {

--- a/assets/opstools/AppBuilder/classes/views/ABViewDataCollection.js
+++ b/assets/opstools/AppBuilder/classes/views/ABViewDataCollection.js
@@ -1119,32 +1119,41 @@ export default class ABViewDataCollection extends ABView {
 
 			// updated values
 			var values = data.data;
+
+			// use the Object's defined Primary Key:
+			var PK = this.model.object.PK();
+			if (!values[PK]) {
+				PK = 'id';
+			}
+
 			if (values) {
 
-				if (this.__dataCollection.exists(values.id)) {
+				if (this.__dataCollection.exists(values[PK])) {
+					var cond = { where:{} };
+					cond.where[PK] = values[PK];
 					// this data collection has the record so we need to query the server to find out what it's latest data is so we can update all instances
-					this.model.staleRefresh({ where: { id: values.id } }).then((res) => {
+					this.model.staleRefresh(cond).then((res) => {
 
 						// check to make sure there is data to work with
 						if (Array.isArray(res.data) && res.data.length) {
 							// tell the webix data collection to update using their API with the row id (values.id) and content (res.data[0]) 
-							if (this.__dataCollection.exists(values.id)) {
-								this.__dataCollection.updateItem(values.id, res.data[0]);
+							if (this.__dataCollection.exists(values[PK])) {
+								this.__dataCollection.updateItem(values[PK], res.data[0]);
 							}
 
 							// If the update item is current cursor, then should tell components to update.
 							var currData = this.getCursor();
-							if (currData && currData.id == values.id) {
+							if (currData && currData[PK] == values[PK]) {
 								this.emit("changeCursor", currData);
 							}
 						} else {
 							// If there is no data in the object then it was deleted...lets clean things up
 							// If the deleted item is current cursor, then the current cursor should be cleared.
 							var currId = this.getCursor();
-							if (currId == values.id)
+							if (currId == values[PK])
 								this.emit("changeCursor", null);
 
-							this.__dataCollection.remove(values.id);
+							this.__dataCollection.remove(values[PK]);
 						}
 					});
 

--- a/assets/opstools/AppBuilder/classes/views/ABViewDataCollection.js
+++ b/assets/opstools/AppBuilder/classes/views/ABViewDataCollection.js
@@ -1112,10 +1112,14 @@ export default class ABViewDataCollection extends ABView {
 		// We are subscribing to notifications from the server that an item may be stale and needs updating
 		// We will improve this later and verify that it needs updating before attempting the update on the client side
 		AD.comm.hub.subscribe('ab.datacollection.stale', (msg, data) => {
+			
+			// if we don't have a datasource or model, there is nothing we can do here:
 			// Verify the datasource has the object we are listening for if not just stop here
-			if (this.datasource &&
-				this.datasource.id != data.objectId)
-				return;
+			if (!this.datasource || !this.model || this.datasource.id != data.objectId) { 
+				return; 
+			}
+
+				
 
 			// updated values
 			var values = data.data;


### PR DESCRIPTION
This branch is my attempt to fix the barrage of SQL requests our `ab.datacollection.stale` socket updates generate.

In summary, there is now a new `ABModel.staleRefresh()` method that gets called in the processing of the socket update.  This method attempts to queue up as many similar stale request alerts as it can.  Then after 200ms after the last request, it then processes them all in a single request. (in the past each request would generate a request on the server).

In my initial testing, a single Add a registration, then a Delete a registration would generate 98 `.stale` messages.  It now get's processed in 1 request (plus 1 for the count() ) where as before it was 98 requests (plus 98 for the count()s) ...

