### PR TITLE
Add a new global filter option for grids

### DIFF
--- a/assets/opstools/AppBuilder/classes/rules/ABViewGridFilterMenu.js
+++ b/assets/opstools/AppBuilder/classes/rules/ABViewGridFilterMenu.js
@@ -53,6 +53,7 @@ export default class ABViewGridFilterMenu {
 			
 			filterOptionRadio: idBase + '_filterOptionRadio',
 			filterUser: idBase + '_filterUser',
+			filterGlobal: idBase + "_filterGlobal",
 			filterMenuLayout: idBase + '_filterMenuLayout',
 
 			needLoadAllLabel: idBase + '_needLoadAll',
@@ -85,7 +86,8 @@ export default class ABViewGridFilterMenu {
 						options:[
 							{"id": 0, "value": "Do not Allow User filters"},
 							{"id": 1, "value": "Enable User filters"},
-							{"id": 2, "value": "Use a filter menu"}
+							{"id": 2, "value": "Use a filter menu"},
+							{"id": 3, "value": "Use a global filter input"}
 						],
 						vertical: true,
 						label: "Filter Option",
@@ -98,7 +100,21 @@ export default class ABViewGridFilterMenu {
 					},
 
 					{
-						view: "segmented",
+						view: "radio",
+						id: ids.filterGlobal,
+						hidden: true,
+						vertical: true,
+						label: "Show",
+						labelWidth: App.config.labelWidthLarge,
+						options: [
+							{ id: "default", value: "All matching records" },
+							{ id: "single", value: "Single records only"}
+						]
+					},
+
+					{
+						view: "radio",
+						vertical: true,
 						id: ids.filterUser,
 						hidden: true,
 						value: "toolbar",
@@ -236,15 +252,23 @@ export default class ABViewGridFilterMenu {
 				switch(JSON.parse(value)) {
 					case 1: // Enable User filters
 						$$(ids.filterMenuLayout).hide();
+						$$(ids.filterGlobal).hide();
 						$$(ids.filterUser).show();
 						break;
 					case 2: // Use a filter menu
 						$$(ids.filterUser).hide();
+						$$(ids.filterGlobal).hide();
 						$$(ids.filterMenuLayout).show();
+						break;
+					case 3: // Use a filter menu
+						$$(ids.filterUser).hide();
+						$$(ids.filterMenuLayout).hide();
+						$$(ids.filterGlobal).show();
 						break;
 					default:
 						$$(ids.filterUser).hide();
 						$$(ids.filterMenuLayout).hide();
+						$$(ids.filterGlobal).hide();
 						break;
 				}
 			},
@@ -319,6 +343,8 @@ export default class ABViewGridFilterMenu {
 			$$(this.ids.filterOptionRadio).setValue(this.filterOption);
 
 			$$(this.ids.filterUser).setValue(settings.userFilterPosition || "toolbar");
+			
+			$$(this.ids.filterGlobal).setValue(settings.globalFilterPosition || "default");
 
 			if (settings.queryRules) {
 				settings.queryRules.forEach((ruleSettings)=> {
@@ -365,6 +391,9 @@ export default class ABViewGridFilterMenu {
 				this.filterRulesList.forEach((r)=>{
 					settings.queryRules.push(r.toSettings());
 				});
+				break;
+			case 3:
+				settings.globalFilterPosition = $$(this.ids.filterGlobal).getValue();
 				break;
 		}
 

--- a/assets/opstools/AppBuilder/classes/views/ABViewGrid.js
+++ b/assets/opstools/AppBuilder/classes/views/ABViewGrid.js
@@ -923,7 +923,8 @@ export default class ABViewGrid extends ABViewWidget  {
 			buttonExport: App.unique(idBase+'_buttonExport'),
 
 			filterMenutoolbar: App.unique(idBase+'_filterMenuToolbar'),
-			resetFilterButton: App.unique(idBase+'_resetFilterButton')
+			resetFilterButton: App.unique(idBase+'_resetFilterButton'),
+			globalFilterForm: App.unique(idBase+'_globalFilterForm')
 
 		}
 		
@@ -977,6 +978,11 @@ export default class ABViewGrid extends ABViewWidget  {
 		var isFiltered = false,
 			waitMilliseconds = 50,
 			filterTimeoutId;
+			
+		var globalFilterPosition = "default";
+		if (this.settings.gridFilter && this.settings.gridFilter.globalFilterPosition) {
+			globalFilterPosition = this.settings.gridFilter.globalFilterPosition;
+		}
 
 		let DataTable = new ABWorkspaceDatatable(App, idBase, settings);
 		let PopupMassUpdateComponent = new ABPopupMassUpdate(App, idBase+"_mass");
@@ -1049,6 +1055,16 @@ export default class ABViewGrid extends ABViewWidget  {
 				}
 				else {
 					$$(rowFilterForm.ui.id).hide();
+				}
+
+				if (this.settings.gridFilter.filterOption == 3) {
+					$$(ids.globalFilterForm).show();
+					if (this.settings.gridFilter.globalFilterPosition == "single") {
+						$$(DataTable.ui.id).hide();
+					}
+				}
+				else {
+					$$(ids.globalFilterForm).hide();
 				}
 				
 				if (this.settings.isSortable == false) {
@@ -1181,6 +1197,36 @@ export default class ABViewGrid extends ABViewWidget  {
 				type: "space",
 				padding: 17,
 				rows: [
+					{
+						id: ids.globalFilterForm,
+						view:"text",
+						hidden: true,
+						placeholder:"Search or scan a barcode to see results",
+						on:{
+							onTimedKeyPress:function(){
+								var text = this.getValue().toLowerCase();
+								var table = $$(DataTable.ui.id);
+								var columns = table.config.columns;
+								var count = 0;
+								table.filter(function(obj){
+									for (var i=0; i<columns.length; i++) {
+										if (obj[columns[i].id] && obj[columns[i].id].toString().toLowerCase().indexOf(text) !== -1) {
+											count += 1;
+											return true
+										};
+									}
+									return false;
+								});
+								if (globalFilterPosition == "single") {
+									if (count == 1) {
+										table.show();
+									} else {
+										table.hide();
+									}
+								}
+							}
+						}
+					},
 					rowFilterForm.ui,
 					{
 						view: 'toolbar',

--- a/assets/opstools/AppBuilder/classes/views/ABViewGrid.js
+++ b/assets/opstools/AppBuilder/classes/views/ABViewGrid.js
@@ -1204,24 +1204,39 @@ export default class ABViewGrid extends ABViewWidget  {
 						placeholder:"Search or scan a barcode to see results",
 						on:{
 							onTimedKeyPress:function(){
-								var text = this.getValue().toLowerCase();
+								var text = this.getValue().trim().toLowerCase().split(" ");
 								var table = $$(DataTable.ui.id);
 								var columns = table.config.columns;
 								var count = 0;
+								var matchArray = [];
 								table.filter(function(obj){
+									matchArray = [];
+									// console.log("filter", obj);
 									for (var i=0; i<columns.length; i++) {
-										if (obj[columns[i].id] && obj[columns[i].id].toString().toLowerCase().indexOf(text) !== -1) {
-											count += 1;
-											return true
-										};
+										for (var x=0; x<text.length; x++) {
+											var searchFor = text[x];
+											if (obj[columns[i].id] && obj[columns[i].id].toString().toLowerCase().indexOf(searchFor) !== -1) {
+												// console.log("matched on:", searchFor);
+												if (matchArray.indexOf(searchFor) == -1) {
+													matchArray.push(searchFor);
+												}
+											}
+										}
 									}
-									return false;
+									// console.log("Filter By:", text.length, text);
+									// console.log("Matches:", matchArray);
+									if (matchArray.length == text.length) {
+										count++;
+										return true;
+									} else {
+										return false;
+									}
 								});
 								if (globalFilterPosition == "single") {
 									if (count == 1) {
 										table.show();
 									} else {
-										table.hide();
+										table.hide(); 
 									}
 								}
 							}


### PR DESCRIPTION
This gives the builder the options to allow users to filter globally across an entire datacollection's data. There is an additional setting that will hide the data grid if more than one record or no records match your search. This will be used to simplify UX so we can present users with the record they are looking for.