### PR TITLE
hotfix missing access level for child view inits

### DIFF
--- a/assets/opstools/AppBuilder/classes/platform/views/ABViewConditionalContainer.js
+++ b/assets/opstools/AppBuilder/classes/platform/views/ABViewConditionalContainer.js
@@ -258,8 +258,8 @@ module.exports = class ABViewConditionalContainer extends ABViewConditionalConta
          ]
       };
 
-      var _init = (options) => {
-         baseComp.init(options);
+      var _init = (options, accessLevel) => {
+         baseComp.init(options, accessLevel);
 
          this.populateFilterComponent();
 


### PR DESCRIPTION
Add the accessLevel param to the _init function so we can pass it down to child view loads.