### PR TITLE
The default settings for filtering a data grid were not set because w…

### DIFF
--- a/assets/opstools/AppBuilder/classes/platform/views/ABViewGrid.js
+++ b/assets/opstools/AppBuilder/classes/platform/views/ABViewGrid.js
@@ -754,6 +754,8 @@ module.exports = class ABViewGrid extends ABViewGridCore {
          detailsView: this.settings.detailsPage,
          editView: this.settings.editPage,
          isEditable: this.settings.isEditable,
+         isSortable: this.settings.isSortable,
+         gridFilter: this.settings.gridFilter,
          massUpdate: this.settings.massUpdate,
          configureHeaders: false,
          summaryColumns: this.settings.objectWorkspace.summaryColumns,
@@ -1418,6 +1420,10 @@ module.exports = class ABViewGrid extends ABViewGridCore {
    }
 
    populatePopupEditors(view, dataSource) {
+      // moved this up because we do not need the object to populate defaults and
+      // default settings were getting skipped when initialized
+      PopupFilterProperty.setSettings(view.settings.gridFilter);
+
       var dv = this.datacollection;
       if (!dv) return;
 
@@ -1440,7 +1446,6 @@ module.exports = class ABViewGrid extends ABViewGridCore {
       );
 
       PopupFilterProperty.objectLoad(object);
-      PopupFilterProperty.setSettings(view.settings.gridFilter);
 
       PopupSummaryColumnsComponent.objectLoad(object, view);
       PopupSummaryColumnsComponent.setValue(


### PR DESCRIPTION
…e were skipping them due to the fact that the object had not been set yet.