### PR TITLE
store and use translated text in selection binding feature

### DIFF
--- a/assets/opstools/AppBuilder/classes/platform/dataFields/ABFieldConnect.js
+++ b/assets/opstools/AppBuilder/classes/platform/dataFields/ABFieldConnect.js
@@ -821,16 +821,30 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
          if (!$$(options.filterValue)) {
             // this happens in the Interface Builder when only the single form UI is displayed
             readOnly = true;
-            placeholderReadOnly =
-               "Must select item from 'PARENT ELEMENT' first.";
+            let select1 = L(
+               "ab.dataField.connect.placeholder_parentElementSelect1",
+               "Must select item from '"
+            );
+            let select2 = L(
+               "ab.dataField.connect.placeholder_parentElementSelect2",
+               "' first."
+            );
+            placeholderReadOnly = select1 + "PARENT ELEMENT" + select2;
          } else {
             let val = this.getValue($$(options.filterValue));
             if (!val) {
                // if there isn't a value on the parent select element set this one to readonly and change placeholder text
                readOnly = true;
                let label = $$(options.filterValue);
-               placeholderReadOnly =
-                  "Must select item from '" + label.config.name + "' first.";
+               let select1 = L(
+                  "ab.dataField.connect.placeholder_parentElementSelect1",
+                  "Must select item from '"
+               );
+               let select2 = L(
+                  "ab.dataField.connect.placeholder_parentElementSelect2",
+                  "' first."
+               );
+               placeholderReadOnly = select1 + label.config.label + select2;
             }
          }
       }

--- a/assets/opstools/AppBuilder/classes/platform/views/ABViewFormConnect.js
+++ b/assets/opstools/AppBuilder/classes/platform/views/ABViewFormConnect.js
@@ -734,6 +734,7 @@ module.exports = class ABViewFormConnect extends ABViewFormConnectCore {
          labelWidth: 0,
          paddingY: 0,
          paddingX: 0,
+         label: field.label,
          css: "ab-custom-field",
          name: field.columnName,
          body: {


### PR DESCRIPTION
We now use a translated string for the placeholder text shown in the connected fields that are dependent on one another. We also store the translated field's label in the webix config so we can use it later when building the placeholder text.