### PR TITLE
data views currently only work well inside tabs because we rerender t…

### DIFF
--- a/assets/opstools/AppBuilder/classes/platform/views/ABViewDataview.js
+++ b/assets/opstools/AppBuilder/classes/platform/views/ABViewDataview.js
@@ -147,6 +147,9 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
             emitter: dc,
             eventName: "loadData",
             listener: () => {
+               // we need to empty out any rows rendered because they were
+               // part of a different set of data.
+               com.emptyView();
                com.renderData();
             }
          });
@@ -270,6 +273,18 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
          return this.yPosition || 0;
       };
 
+      com.emptyView = () => {
+         var flexlayout = {
+            id: ids.dataFlexView,
+            view: "flexlayout",
+            paddingX: 15,
+            paddingY: 19,
+            type: "space",
+            cols: []
+         };
+         webix.ui(flexlayout, $$(ids.scrollview), $$(ids.dataFlexView));
+      };
+
       com.renderData = () => {
          var editPage = this.settings.editPage;
          var detailsPage = this.settings.detailsPage;
@@ -283,8 +298,10 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
 
          var Layout = $$(ids.dataFlexView) || $$(ids.component);
 
+         if (!Layout || isNaN(Layout.$width)) return;
+
          var recordWidth = Math.floor(
-            (Layout.$width - 20 - parseInt(this.settings.xCount) * 20) /
+            (Layout.$width - 40 - parseInt(this.settings.xCount) * 20) /
                parseInt(this.settings.xCount)
          );
 
@@ -356,7 +373,7 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
                type: "space",
                cols: records
             };
-            webix.ui(flexlayout, $$(ids.component));
+            webix.ui(flexlayout, $$(ids.scrollview), $$(ids.dataFlexView));
 
             for (var i = this._startPos; i < stopPos; i++) {
                let detailCom = _.cloneDeep(super.component(App, rows[i].id));


### PR DESCRIPTION
…he entire tab's views when loading but on our normal views we do not have to and when a cursor was changed we never were changing the loaded data.