### PR TITLE
[hotfix] Store the column name of the record we want to filter by

### DIFF
--- a/assets/opstools/AppBuilder/classes/platform/dataFields/ABFieldConnect.js
+++ b/assets/opstools/AppBuilder/classes/platform/dataFields/ABFieldConnect.js
@@ -818,7 +818,7 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
       // to make sure the UX helps the user know what to do.
       var placeholderReadOnly = null;
       if (options.filterValue && options.filterKey) {
-         if (!$$(options.filterValue)) {
+         if (!$$(options.filterValue.ui.id)) {
             // this happens in the Interface Builder when only the single form UI is displayed
             readOnly = true;
             let select1 = L(
@@ -831,11 +831,11 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
             );
             placeholderReadOnly = select1 + "PARENT ELEMENT" + select2;
          } else {
-            let val = this.getValue($$(options.filterValue));
+            let val = this.getValue($$(options.filterValue.ui.id));
             if (!val) {
                // if there isn't a value on the parent select element set this one to readonly and change placeholder text
                readOnly = true;
-               let label = $$(options.filterValue);
+               let label = $$(options.filterValue.ui.id);
                let select1 = L(
                   "ab.dataField.connect.placeholder_parentElementSelect1",
                   "Must select item from '"
@@ -872,9 +872,15 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
                      JSON.stringify(options.filters)
                   );
                   // only add filters if we pass valid value and key
-                  if (options.filterValue && options.filterKey) {
+                  if (
+                     options.filterValue &&
+                     options.filterKey &&
+                     $$(options.filterValue.ui.id)
+                  ) {
                      // get the current value of the parent select box
-                     let parentVal = this.getValue($$(options.filterValue));
+                     let parentVal = this.getValue(
+                        $$(options.filterValue.ui.id)
+                     );
                      if (parentVal) {
                         // if there is a value create a new filter rule
                         var filter = {
@@ -967,10 +973,10 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
                false
             );
             // add a change listener to the selectivity instance we are filtering our options list by.
-            if (options.filterValue && $$(options.filterValue)) {
-               var parentDomNode = $$(options.filterValue).$view.querySelector(
-                  ".connect-data-values"
-               );
+            if (options.filterValue && $$(options.filterValue.ui.id)) {
+               var parentDomNode = $$(
+                  options.filterValue.ui.id
+               ).$view.querySelector(".connect-data-values");
                parentDomNode.addEventListener(
                   "change",
                   (e) => {

--- a/assets/opstools/AppBuilder/classes/platform/views/ABViewFormConnect.js
+++ b/assets/opstools/AppBuilder/classes/platform/views/ABViewFormConnect.js
@@ -38,10 +38,16 @@ function _onShow(App, compId, instance, component) {
       instance.settings.filterConnectedValue &&
       instance.settings.filterConnectedValue.indexOf(":") > -1
    ) {
-      filterValue =
-         instance.parent.viewComponents[
+      Object.keys(instance.parent.viewComponents).forEach((key, index) => {
+         if (
+            instance.parent.viewComponents[key].ui.name ==
             instance.settings.filterConnectedValue.split(":")[0]
-         ].ui.id;
+         ) {
+            filterValue = instance.parent.viewComponents[key];
+         }
+      });
+      // if not found stop
+      if (!filterValue) return;
       filterKey = instance.settings.filterConnectedValue.split(":")[1];
       filterColumn = instance.settings.filterConnectedValue.split(":")[2];
    }
@@ -386,8 +392,8 @@ module.exports = class ABViewFormConnect extends ABViewFormConnectCore {
                      // get the component we are referencing so we can display its label
                      let formComponent = view.parent.viewComponents[element.id]; // need to ensure that just looking at parent is okay in all cases
                      filterConnectedOptions.push({
-                        id: element.id + ":" + fieldToCheck, // store the element id because the ui id changes on each load
-                        value: formComponent.ui.name // should be the translated field label
+                        id: formComponent.ui.name + ":" + fieldToCheck, // store the columnName name because the ui id changes on each load
+                        value: formComponent.ui.label // should be the translated field label
                      });
                   }
                }


### PR DESCRIPTION
Originally we stored the interface component ID but when we have "Add New" views we dynamically build the form using unique ID's thus losing this feature.