### PR TITLE
[hotfix] Always allow access to components inside a dataview.

### DIFF
--- a/assets/opstools/AppBuilder/classes/platform/views/ABViewDataview.js
+++ b/assets/opstools/AppBuilder/classes/platform/views/ABViewDataview.js
@@ -315,7 +315,6 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
          var detailsPage = this.settings.detailsPage;
          var editTab = this.settings.editTab;
          var detailsTab = this.settings.detailsTab;
-         var accessLevel = this.parent.getUserAccess();
          var records = [];
 
          var dc = this.datacollection;
@@ -387,7 +386,7 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
 
             if (Layout.addView) {
                Layout.addView(detailCom.ui, -1);
-               detailCom.init(null, accessLevel);
+               detailCom.init(null, 2); // 2 - Always allow access to components inside data view
                setTimeout(detailCom.logic.displayData(rows[i]), 0);
             } else {
                records.push(detailCom.ui);
@@ -407,7 +406,7 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
 
             for (var i = this._startPos; i < stopPos; i++) {
                let detailCom = _.cloneDeep(super.component(App, rows[i].id));
-               detailCom.init(null, accessLevel);
+               detailCom.init(null, 2); // 2 - Always allow access to components inside data view
                setTimeout(detailCom.logic.displayData(rows[i]), 0);
             }
          }


### PR DESCRIPTION
The components inside a dataview are just detail views so we do not need to check if the users should have access to them but grant access automatically.