### PR TITLE
prevent unnecessary reload of data on init

### DIFF
--- a/assets/opstools/AppBuilder/classes/platform/ABDataCollection.js
+++ b/assets/opstools/AppBuilder/classes/platform/ABDataCollection.js
@@ -123,7 +123,9 @@ module.exports = class ABDataCollection extends ABDataCollectionCore {
             }
 
             // this is the same item that was already bound...don't reload data
-            if (JSON.stringify(this.__reloadWheres) == JSON.stringify(wheres)) {
+            if (JSON.stringify(this.__reloadWheres) == JSON.stringify(wheres) ||
+               (wheres.rules && wheres.rules.length == 0)
+            ) {
                return;
             } else {
                // now that we have the modified wheres the dataCollections wheres


### PR DESCRIPTION
Right now when the initial load of content comes if we have no "rules" we are reloading the data which causes unnecessary load to the database and delay for the user to interact with pages.