### PR TITLE
[fix] search for GL balances by COA category

### DIFF
--- a/scripts/ns_app/CLOSE_FY_PROCESS.sql
+++ b/scripts/ns_app/CLOSE_FY_PROCESS.sql
@@ -156,6 +156,11 @@ BEGIN
          UUID() `uuid`
       FROM
          `AB_MyTeamFinance_ResponsibilityCenter` RC
+      INNER JOIN `AB_AccountingApp_GLSegment` GL -- Do not add empty 3500 records
+         ON RC.`RC Name` = GL.`RC Code`
+         WHERE
+         GL.`COA Num` LIKE "3500"  OR
+         GL.`COA Num` LIKE "3991" 
    ) r
    ON DUPLICATE KEY UPDATE
    `Starting Balance` = r.`Starting Balance`,
@@ -163,11 +168,15 @@ BEGIN
    `Debit` = 0,
    `updated_at` = NOW();
 
+   -- Remove empty 3500 records
+   DELETE FROM `AB_AccountingApp_GLSegment`
+	WHERE `COA Num` LIKE CONCAT("%",NEW_FP,"-3500%" ) AND `Starting Balance`= '0' AND`Running Balance`='0' AND`Debit`='0' AND`Credit`='0';
+
    -- update running balance
    UPDATE `AB_AccountingApp_GLSegment`
    SET 
       `Running Balance` = `Starting Balance` 
-   WHERE `Balndx` LIKE ('%M01-3500-%') ;
+   WHERE `Balndx` LIKE CONCAT("%",NEW_FP,"-3500%" );
 
 -- 5. Find All M1 Balances With Account Type = Income, Expense, or Equity
 -- 6. Update M1 Balances

--- a/scripts/ns_app/CLOSE_FY_PROCESS.sql
+++ b/scripts/ns_app/CLOSE_FY_PROCESS.sql
@@ -194,25 +194,28 @@ BEGIN
       GL.`COA Num`, -- Same as Original Balance Record
       GL.`RC Code`,
       IFNULL(
-         IF( 
-         ((GL.`COA Num` > 7999 OR GL.`COA Num` < 4000) AND GL.`COA Num` != "3991"),
-            GL.`Running Balance`,
-            0  
+         IF( -- Income 1590392412833, Expense 1585806356789, or Equity 1585806356643
+         (AC.`Category` LIKE '1590392412833' OR AC.`Category` LIKE '1585806356789' OR AC.`Category` LIKE '1585806356643' or GL.`COA Num` LIKE "3991"),
+         -- (GL.`COA Num` > 9999 OR GL.`COA Num` < 4000) AND (GL.`COA Num` > 49999 OR GL.`COA Num` < 40000) AND GL.`COA Num` != "3991"),
+            0,  
+            GL.`Running Balance`
          )
          , 0) `Starting Balance`,
       0 `Credit`,
       0 `Debit`,
       IFNULL(
          IF( 
-         ((GL.`COA Num` > 7999 OR GL.`COA Num` < 4000) AND GL.`COA Num` != "3991"),
-            GL.`Running Balance`,
-            0  
+         (AC.`Category` LIKE '1590392412833' OR AC.`Category` LIKE '1585806356789' OR AC.`Category` LIKE '1585806356643' or GL.`COA Num` LIKE "3991"),
+            0,  
+            GL.`Running Balance`
          )
          , 0)  `Running Balance`,
       NOW() `created_at`,
       NOW() `updated_at`
       FROM
       `AB_AccountingApp_GLSegment` GL
+      LEFT JOIN `AB_AccountingApp_Account` AC
+      ON AC.`Acct Num` = GL.`COA Num`
       WHERE
       GL.`FY Period` LIKE FP_Last AND
       GL.`COA Num` != "3500" 


### PR DESCRIPTION
Searching this area by hard coded numbers is too difficult: 

the live system has numbers outside of the range I was expecting such as `11111` and `41111`

Using a left-join query to get the category.